### PR TITLE
VS-5: Proper update of variant-bearing patients list

### DIFF
--- a/variant-store/src/main/java/org/phenotips/variantstore/db/solr/SolrVariantUtils.java
+++ b/variant-store/src/main/java/org/phenotips/variantstore/db/solr/SolrVariantUtils.java
@@ -196,6 +196,9 @@ public final class SolrVariantUtils
         doc.setField(VariantsSchema.AC_TOT, 0);
         doc.setField(VariantsSchema.GT_HET, 0);
         doc.setField(VariantsSchema.GT_HOM, 0);
+   
+        // initialize multi-value field so that it clones as an empty list rather than a null value
+        doc.setField(VariantsSchema.CALLSET_IDS, Collections.emptyList());      
         return doc;
     }
 
@@ -209,7 +212,7 @@ public final class SolrVariantUtils
      *                  search.
      */
     public static void addVariantToDoc(SolrDocument doc, GAVariant variant, String callsetId, boolean isPublic) {
-        doc.setField(VariantsSchema.CALLSET_IDS, callsetId);
+        addMultiFieldValue(doc, VariantsSchema.CALLSET_IDS, callsetId);
 
         GACall call = variant.getCalls().get(0);
         int copies = 0;
@@ -238,7 +241,14 @@ public final class SolrVariantUtils
         setCallsetField(doc, callsetId, VariantsSchema.EXOMISER_GENE_COMBINED_SCORE,
                 safeValueOf(getInfo(call, GACallInfoFields.EXOMISER_GENE_COMBINED_SCORE)));
     }
-
+    
+    private static void addMultiFieldValue(SolrDocument doc, String key, Object value) {
+         // clone array, sometimes it's unmodifiable
+         List<Object> values = new ArrayList<>(doc.getFieldValues(key));
+         values.add(value);
+         doc.setField(key, values);
+    }
+ 
     /**
      * Set a field on the doc thats unique to a callset (i.e. not share by two
      * callsets). For example, a variant quality indicator would be specific to


### PR DESCRIPTION
Variant documents were only holding on to one patient (callsetID) at a time, preventing patients in a common database from sharing a variant and being matched by it. This bug was occurring because the list meant to contain _all_ pertinent callsetIDs was being re-set every time an exome containing that variant was uploaded. Bug was fixed with (a) the initialization of a cloneable callsetID field, (b) the creation of method addMultiFieldValue(), which clones the list of callsetIDs and appends to it (rather than resetting it.)
